### PR TITLE
inital GH Action CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+ # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -1,0 +1,52 @@
+name: CI_build
+
+on: [push, pull_request]
+
+jobs:
+  build_windows:
+
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        build_configuration: [Release]
+        build_platform: [x64, Win32]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v5
+      if: matrix.build_platform == 'x64'
+      with:
+        python-version: '3.12'
+        architecture: x64
+
+    - uses: actions/setup-python@v5
+      if: matrix.build_platform == 'ARM64'
+      with:
+        python-version: '3.12'
+        architecture: arm64
+
+    - uses: actions/setup-python@v5
+      if: matrix.build_platform == 'Win32'
+      with:
+        python-version: '3.12'
+        architecture: x86
+
+    - name: generate cmake
+      run: |
+           mkdir _build
+           cd _build
+           cmake -G "Visual Studio 17 2022" -A ${{ matrix.build_platform }} -T "v143" ..
+
+    - name: build cmake
+      run: |
+           cd _build
+           cmake --build . --config ${{ matrix.build_configuration }}
+
+    - name: Archive artifacts for ${{ matrix.build_platform }}
+      if: matrix.build_configuration == 'Release'
+      uses: actions/upload-artifact@v4
+      with:
+          name: plugin_dll_${{ matrix.build_platform }}
+          path: _build\${{ matrix.build_configuration }}\pycalc.dll


### PR DESCRIPTION
- x64 and x86 release build of the plugin with python 3.12 , see https://github.com/chcg/pycal_notepad-plus-plus/actions/runs/12448099402
Possible improvements:
- no packaging with python libs is available could be probably done by cpack from cmake and the action could be extended to create complete releases
- debug build is not working yet as linking expects python debug libs which are not available by GH python action
- arm64 python could be not installed on GH windows runner
